### PR TITLE
Add get_version, get_serialnum, and viewport

### DIFF
--- a/DirectPy.py
+++ b/DirectPy.py
@@ -21,8 +21,7 @@ class DIRECTV:
         self.port = port
         self.clientAddr = clientAddr
         self.standby = False
-        self.channel_primary = '0'
-        self.channel_secondary = '0'
+        self.channel = '0'
         self.valid_keys = ['power', 'poweron', 'poweroff', 'format', 'pause',
                            'rew', 'replay', 'stop', 'advance', 'ffwd',
                            'record', 'play', 'guide', 'active', 'list', 'exit',
@@ -82,20 +81,16 @@ class DIRECTV:
 
         return jResp
 
-    def get_tuned(self, videowindow='primary'):
+    def get_tuned(self):
         """Returns the channel and program information of the current
 
         channel."""
         jResp = requests.get(
-            '%s/tv/getTuned?clientAddr=%s&videoWindow=%s' %
-            (self.base_url, self.clientAddr, videowindow)).json()
+            '%s/tv/getTuned?clientAddr=%s' %
+            (self.base_url, self.clientAddr)).json()
         if jResp['status']['code'] == 200:
-            if videowindow == 'secondary':
-                self.channel_secondary = self._combine_channel(
-                    jResp['major'], jResp['minor'])
-            else:
-                self.channel_primary = self._combine_channel(
-                    jResp['major'], jResp['minor'])
+            self.channel = self._combine_channel(jResp['major'],
+                                                 jResp['minor'])
 
         return jResp
 
@@ -109,7 +104,7 @@ class DIRECTV:
             '%s/tv/tune?major=%s&minor=%s&clientAddr=%s' %
             (self.base_url, major, minor, self.clientAddr)).json()
         if jResp['status']['code'] == 200:
-            self.channel_primary = channel
+            self.channel = channel
 
         return jResp
 
@@ -150,7 +145,7 @@ class DIRECTV:
 
         return jResp
 
-    def get_serialnum(self):
+    def get_serial_num(self):
         """Returns the serial number."""
 
         jResp = requests.get('%s/info/getSerialNum' % (self.base_url)).json()

--- a/DirectPy.py
+++ b/DirectPy.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import requests
 
+
 class DIRECTV:
     """DirectPy.py by Eric Walters (github.com/sentry07)
 
@@ -14,23 +15,26 @@ class DIRECTV:
     receivers. To control a client receiver, you must
     know the MAC address and reference it without colons.
     EX: DIRECTV('192.168.1.10',clientAddr='000A959D6816')
-    """    
+    """
     def __init__(self, ip, port=8080, clientAddr='0'):
         self.ip = ip
         self.port = port
         self.clientAddr = clientAddr
         self.standby = False
-        self.channel = '0'
-        self.valid_keys = ['power', 'poweron', 'poweroff', 'format', 'pause', 'rew', 'replay', 'stop',
-                          'advance', 'ffwd', 'record', 'play', 'guide', 'active', 'list', 'exit',
-                          'back', 'menu', 'info', 'up', 'down', 'left', 'right', 'select', 'red',
-                          'green', 'yellow', 'blue', 'chanup', 'chandown', 'prev', '0', '1', '2',
-                          '3', '4', '5', '6', '7', '8', '9', 'dash', 'enter']
+        self.channel_primary = '0'
+        self.channel_secondary = '0'
+        self.valid_keys = ['power', 'poweron', 'poweroff', 'format', 'pause',
+                           'rew', 'replay', 'stop', 'advance', 'ffwd',
+                           'record', 'play', 'guide', 'active', 'list', 'exit',
+                           'back', 'menu', 'info', 'up', 'down', 'left',
+                           'right', 'select', 'red', 'green', 'yellow', 'blue',
+                           'chanup', 'chandown', 'prev', '0', '1', '2', '3',
+                           '4', '5', '6', '7', '8', '9', 'dash', 'enter']
 
-        self.base_url = 'http://%s:%s' % (ip,port)
+        self.base_url = 'http://%s:%s' % (ip, port)
 
         self.get_standby()
-        if self.standby == False:
+        if not self.standby:
             self.get_tuned()
 
     @staticmethod
@@ -42,79 +46,113 @@ class DIRECTV:
             major = channel
             minor = 65535
 
-        return major,minor
+        return major, minor
 
     @staticmethod
-    def _combine_channel(major,minor):
-        """Return the combined channel number. If minor == 65535, there is no minor channel number."""
+    def _combine_channel(major, minor):
+        """Return the combined channel number. If minor == 65535, there is no
+
+        minor channel number."""
         if minor == 65535:
             return str(major)
         else:
-            return '%d-%d' % (major,minor)
+            return '%d-%d' % (major, minor)
 
     def get_standby(self):
         """Return standby status of the receiver."""
-        jResp = requests.get('%s/info/mode?clientAddr=%s' % (self.base_url,self.clientAddr)).json()
-        
+        jResp = requests.get('%s/info/mode?clientAddr=%s' %
+                             (self.base_url, self.clientAddr)).json()
+
         """Handle clientAddrs that are offline/not reporting for some reason"""
         if jResp['status']['code'] == 403:
             self.standby = 1
         else:
             self.standby = (jResp['mode'] == 1)
-        
+
         return self.standby
-        
-    def get_channel(self, channel:"'###' or '###-#'"):
+
+    def get_channel(self, channel: "'###' or '###-#'"):
         """Return program information for a channel."""
         if not type(channel) is str:
             raise TypeError('Channel should be a string')
-        major,minor = self._parse_channel(channel)
-        jResp = requests.get('%s/tv/getProgInfo?major=%s&minor=%s&clientAddr=%s' % (self.base_url,major,minor,self.clientAddr)).json()
+        major, minor = self._parse_channel(channel)
+        jResp = requests.get(
+            '%s/tv/getProgInfo?major=%s&minor=%s&clientAddr=%s' %
+            (self.base_url, major, minor, self.clientAddr)).json()
 
         return jResp
 
-    def get_tuned(self):
-        """Returns the channel and program information of the current channel."""
-        jResp = requests.get('%s/tv/getTuned?clientAddr=%s' % (self.base_url,self.clientAddr)).json()
-        if jResp['status']['code'] == 200: 
-            self.channel = self._combine_channel(jResp['major'],jResp['minor'])
-        
+    def get_tuned(self, videowindow='primary'):
+        """Returns the channel and program information of the current
+
+        channel."""
+        jResp = requests.get(
+            '%s/tv/getTuned?clientAddr=%s&videoWindow=%s' %
+            (self.base_url, self.clientAddr, videowindow)).json()
+        if jResp['status']['code'] == 200:
+            if videowindow == 'secondary':
+                self.channel_secondary = self._combine_channel(
+                    jResp['major'], jResp['minor'])
+            else:
+                self.channel_primary = self._combine_channel(
+                    jResp['major'], jResp['minor'])
+
         return jResp
 
-    def tune_channel(self, channel:"'###' or '###-#'"):
+    def tune_channel(self, channel: "'###' or '###-#'"):
         """Change the channel on the receiver."""
         if not type(channel) is str:
             raise TypeError('Channel should be a string')
-        major,minor = self._parse_channel(channel)
+        major, minor = self._parse_channel(channel)
 
-        jResp = requests.get('%s/tv/tune?major=%s&minor=%s&clientAddr=%s' % (self.base_url,major,minor,self.clientAddr)).json()
+        jResp = requests.get(
+            '%s/tv/tune?major=%s&minor=%s&clientAddr=%s' %
+            (self.base_url, major, minor, self.clientAddr)).json()
         if jResp['status']['code'] == 200:
-            self.channel = channel
+            self.channel_primary = channel
 
         return jResp
 
-    def key_press(self, key:str):
+    def key_press(self, key: str):
         """Emulate pressing a key on the remote. See help() for supported keys.
 
-        Supported keys: power, poweron, poweroff, format, 
-        pause, rew, replay, stop, advance, ffwd, record, 
-        play, guide, active, list, exit, back, menu, info, 
-        up, down, left, right, select, red, green, yellow, 
-        blue, chanup, chandown, prev, 0, 1, 2, 3, 4, 5, 
+        Supported keys: power, poweron, poweroff, format,
+        pause, rew, replay, stop, advance, ffwd, record,
+        play, guide, active, list, exit, back, menu, info,
+        up, down, left, right, select, red, green, yellow,
+        blue, chanup, chandown, prev, 0, 1, 2, 3, 4, 5,
         6, 7, 8, 9, dash, enter
         """
         if not type(key) is str:
             raise TypeError('Key should be a string')
         if not key.lower() in self.valid_keys:
             raise ValueError('Invalid key: ' + key)
-        
-        jResp = requests.get('%s/remote/processKey?key=%s&hold=keyPress&clientAddr=%s' % (self.base_url,key,self.clientAddr)).json()
+
+        jResp = requests.get(
+            '%s/remote/processKey?key=%s&hold=keyPress&clientAddr=%s' %
+            (self.base_url, key, self.clientAddr)).json()
 
         return jResp
 
     def get_locations(self):
         """Returns the clientAddr for all devices."""
-        
+
         jResp = requests.get('%s/info/getLocations' % (self.base_url)).json()
-        
+
+        return jResp
+
+    def get_version(self):
+        """Returns the access card ID, received ID, STB software version,
+
+        system time ,and version of current implementation."""
+
+        jResp = requests.get('%s/info/getVersion' % (self.base_url)).json()
+
+        return jResp
+
+    def get_serialnum(self):
+        """Returns the serial number."""
+
+        jResp = requests.get('%s/info/getSerialNum' % (self.base_url)).json()
+
         return jResp

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ dtv.key_press('poweron')
 \# Get the currently tuned channel  
 dtv.get_tuned()  
 
+\# Get the currently tuned channel on PIP
+dtv.get_tuned('secondary')  
+
 \# Set the channel to 249  
 dtv.tune_channel('249')  
 
@@ -29,3 +32,13 @@ dtv.get_channel('264')
 
 \# Emulate pressing the power off button  
 dtv.key_press('poweroff')  
+
+\# Retrieve the different RVU's attached
+dtv.get_locations()
+
+\# Retrieve access card ID, receiver ID, STB software version, system time, and version of current implementation
+dtv.get_version()
+
+\# Retrieve serial number
+dtv.get_serialnum()
+

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 DirectPy
 ========
 
-A Python 2.5+/3 library for interacting with DirecTV receivers. For more information on setting up your receiver to use the API, please see:  
+A Python 2.5+/3 library for interacting with DirecTV receivers. For more information on setting up your receiver to use the API, please see:
 http://forums.solidsignal.com/docs/DTV-MD-0359-DIRECTV_SHEF_Command_Set-V1.3.C.pdf
 
 This class import provides basic functions for controlling a DirecTV receiver, either by setting its
@@ -10,28 +10,25 @@ from the receiver about its status, current channel, and program information.
 
 Example use:
 ============
-from DirectPy import DIRECTV  
+from DirectPy import DIRECTV
 
-\# Initiate a new object using the IP address of the receiver  
-dtv = DIRECTV('192.168.1.10')  
+\# Initiate a new object using the IP address of the receiver
+dtv = DIRECTV('192.168.1.10')
 
-\# Emulate pressing the power on button  
-dtv.key_press('poweron')        
+\# Emulate pressing the power on button
+dtv.key_press('poweron')
 
-\# Get the currently tuned channel  
-dtv.get_tuned()  
+\# Get the currently tuned channel
+dtv.get_tuned()
 
-\# Get the currently tuned channel on PIP
-dtv.get_tuned('secondary')  
+\# Set the channel to 249
+dtv.tune_channel('249')
 
-\# Set the channel to 249  
-dtv.tune_channel('249')  
+\# Get information about the program that is on channel 264
+dtv.get_channel('264')
 
-\# Get information about the program that is on channel 264  
-dtv.get_channel('264')  
-
-\# Emulate pressing the power off button  
-dtv.key_press('poweroff')  
+\# Emulate pressing the power off button
+dtv.key_press('poweroff')
 
 \# Retrieve the different RVU's attached
 dtv.get_locations()


### PR DESCRIPTION
Add calls for get_version and get_serialnum.
Add ability for viewPort allowing to retrieve information for the PIP window.

Not fully tested yet but already wanted you to have a look at.

Note, I also updated based on flake8/pylint.